### PR TITLE
Added `ninja-build`

### DIFF
--- a/distros/debian-bookworm.cfg
+++ b/distros/debian-bookworm.cfg
@@ -291,6 +291,7 @@
                              'sudo',
                              'xdg-user-dirs',
                              'zip',
-                             'zlib1g-dev'
+                             'zlib1g-dev',
+                             "ninja-build"
                            ]
 }


### PR DESCRIPTION
This needs to be added as minimal Debian 12 does not come with it installed. especially for arm build.