### PR TITLE
Remove "nodebug" from stripped AppImage names to make it more obvious…

### DIFF
--- a/overte-builder
+++ b/overte-builder
@@ -2241,7 +2241,7 @@ sub install_into_appimage {
 	);
 
 	info("Creating stripped AppImage...\n");
-	my $appimage_filename_nodebug = $template->fork_id . "-" . $template->version . "-nodebug-x86_64.AppImage";
+	my $appimage_filename_nodebug = $template->fork_id . "-" . $template->version . "-x86_64.AppImage";
 	run($tool_path, $appimage_base, $appimage_filename_nodebug);
 
 	info("Created AppImage with debugging   : ");


### PR DESCRIPTION
… to new uses which AppImage to use.