### PR TITLE
Update metadata

### DIFF
--- a/templates/Overte/appimage.desktop
+++ b/templates/Overte/appimage.desktop
@@ -5,5 +5,5 @@ Terminal=false
 Type=Application
 Exec=/AppRun
 Icon=Overte
-Categories=Graphics
+Categories=Game;Network;Qt;
 X-AppImage-Version=$version

--- a/templates/Overte/appstream.xml
+++ b/templates/Overte/appstream.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright 2023 Dale Glass <dale\@daleglass.net>
-    Copyright 2023 Overte e.V.
+    Copyright 2023-2024 Overte e.V.
 -->
 <component type="desktop-application">
-  <id>org.overte.interface</id>
+  <id>org.overte.Overte</id>
   <metadata_license>FSFAP</metadata_license>
   <project_license>Apache-2.0</project_license>
   <name>Overte</name>
-  <summary>Overte client</summary>
-  <developer_name>Overte e.V.</developer_name>
+  <summary>Overte open-source social-VR client</summary>
+  <summary xml:lang="de">Quelloffene Social-VR Anwendung</summary>
+  <developer id="org.overte">
+    <name>Overte e.V.</name>
+  </developer>
   <content_rating type="oars-1.1">
     <content_attribute id="social-chat">moderate</content_attribute>
     <content_attribute id="social-audio">moderate</content_attribute>
@@ -35,40 +38,79 @@
     </ul>
   </description>
   <categories>
-      <category>Graphics</category>
+      <category>Game</category>
       <category>Network</category>
-      <category>AudioVideo</category>
+      <category>Qt</category>
   </categories>
-  <launchable type="desktop-id">org.overte.interface.desktop</launchable>
+  <launchable type="desktop-id">org.overte.Overte.desktop</launchable>
   <screenshots>
     <screenshot type="default">
       <caption>Creation UI</caption>
       <image>https://overte.org/_images/Create_UI_2.jpeg</image>
     </screenshot>
     <screenshot>
-      <caption>Development meeting</caption>
-      <image>https://overte.org/_images/overte-snap-by-X74hc595-on-2023-02-25_20-34-29.jpg</image>
+      <caption>Hanging out on Maker Monday</caption>
+      <image>https://overte.org/_images/overte-snap-by--on-2022-02-20_19-48-33.jpeg</image>
+    </screenshot>
+    <screenshot>
+      <caption>Kreolis playing in Brainstormer's Club</caption>
+      <image>https://overte.org/_images/overte-snap-by-X74hc595-on-2023-02-26_19-01-20.jpg</image>
+    </screenshot>
+    <screenshot>
+      <caption>Pool toys exploring a fantasy island</caption>
+      <image>https://overte.org/_images/overte-snap-by-X74hc595-on-2023-01-15_22-01-12.jpg</image>
+    </screenshot>
+    <screenshot>
+      <caption>Basinsky showing off his photogrammetry worlds</caption>
+      <image>https://overte.org/_images/overte-snap-by--on-2022-12-14_23-23-03.jpg</image>
+    </screenshot>
+    <screenshot>
+      <caption>Installing new lanterns on the Hub bridge</caption>
+      <image>https://overte.org/_images/overte-snap-by-X74hc595-on-2023-03-27_22-42-02.jpg</image>
     </screenshot>
   </screenshots>
+
+<!--
+  The version of our logo used as desktop icon already has the brand color in it.
+  Maybe we can use another version of the logo on stores?
+  <branding>
+    <color type="primary" scheme_preference="light">#6667AB</color>
+    <color type="primary" scheme_preference="dark">#6667AB</color>
+  </branding>
+-->
 
   <url type="homepage">https://overte.org/</url>
   <url type="bugtracker">https://github.com/overte-org/overte/issues</url>
   <url type="help">https://docs.overte.org/</url>
   <url type="translate">https://weblate.overte.org/</url>
-  <project_group>Internet</project_group>
+  <url type="donation">https://overte.org/donate.html</url>
+  <url type="contribute">https://docs.overte.org/contribute.html</url>
+  <url type="faq">https://docs.overte.org/faq.html</url>
+
+  <supports>
+    <control>pointing</control>
+    <control>keyboard</control>
+    <control>gamepad</control>
+<!--
+    The touch UI gets enabled at compile time when building for Android.
+    It should be possible to enable it for Linux as well somehow.
+    <control>touch</control>
+-->
+  </supports>
+  <recommends>
+    <!-- 10 mbit/s downstream and 2 mbit/s upstream -->
+    <internet bandwidth_mbitps="10">always</internet>
+  </recommends>
 
   <provides>
     <binary>Overte</binary>
   </provides>
 
-<!--
+
   <releases>
-    <release version="3.12.2" date="2013-04-12">
-      <description>
-        <p>Fixes issues X, Y and Z</p>
-      </description>
+    <release version="2024.07.1" date="2024-07-13">
+        <url>https://github.com/overte-org/overte/blob/master/CHANGELOG.md</url>
     </release>
   </releases>
-  <developer_name>$fork_name</developer_name>
--->
+
 </component>


### PR DESCRIPTION
There are metadata changes in relation to our Flathub submission.
Unfortunately, according to [this comment](https://github.com/flathub/flathub/pull/5509#discussion_r1720784809), they require us to put release data into the metadata. So far no one complained about me just adding a link to the changelog, but I assume the version has to be updated on every update.

Other than this, I took the liberty of changing the category. While there essentially isn't a category we fit in properly, I would argue that for users like me, the Internet category fits best, while for many others the Games category fits best.